### PR TITLE
SAR-3853: Removed reliance on deprecated methods

### DIFF
--- a/app/mongo/ETMPNotificationRepository.scala
+++ b/app/mongo/ETMPNotificationRepository.scala
@@ -54,22 +54,22 @@ class ETMPNotificationMongoRepository(implicit mongo: () => DB)
   }
 
    def cacheETMPNotification(notification: CurlETMPNotification): Future[Boolean] = {
-    collection.insert[CurlETMPNotification](notification) map {
-      case wr => false
-    } recover {
-      case _ => true
-    }
-  }
+     collection.insert(ordered = true).one(notification) map {
+       _ => false
+     } recover {
+       case _ => true
+     }
+   }
 
    def retrieveETMPNotification(ackRef: String): Future[Option[ETMPNotification]] = {
-    collection.find(ackRefSelector(ackRef)).one[CurlETMPNotification] map {
+    collection.find(ackRefSelector(ackRef), projection = None).one[CurlETMPNotification] map {
       case Some(record) => Some(CurlETMPNotification.convertToETMPNotification(record))
-      case None => None
+      case None         => None
     }
   }
 
    def wipeETMPNotification : Future[String] = {
-    collection.drop() map {
+    collection.drop(failIfNotFound = false) map {
       _ => "Collection dropped"
     }
   }

--- a/app/mongo/IVOutcomeRepository.scala
+++ b/app/mongo/IVOutcomeRepository.scala
@@ -47,10 +47,12 @@ class IVOutcomeMongoRepository(implicit mongo: () => DB)
     with IVOutcomeRepository {
 
   override def upsertIVOutcome(data: SetupIVOutcome): Future[WriteResult] = {
-    collection.update(BSONDocument("journeyId" -> BSONString(data.journeyId)), data, upsert = true)(BSONDocumentWrites, domainFormatImplicit, global)
+    collection
+      .update(ordered = true)
+      .one(BSONDocument("journeyId" -> data.journeyId), data, upsert = true)(global, BSONDocumentWrites, domainFormatImplicit)
   }
 
   override def fetchIVOutcome(journeyId: String): OptionT[Future, SetupIVOutcome] = {
-    OptionT(collection.find(BSONDocument("journeyId" -> journeyId)).one[SetupIVOutcome])
+    OptionT(collection.find(BSONDocument("journeyId" -> journeyId), projection = None).one[SetupIVOutcome])
   }
 }

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -44,7 +44,7 @@ trait MicroService {
       libraryDependencies ++= appDependencies,
       retrieveManaged := true,
       evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
-      scalaVersion := "2.11.11",
+      scalaVersion := "2.11.12",
       routesGenerator := StaticRoutesGenerator
     )
     .configs(IntegrationTest)

--- a/project/StubServiceBuild.scala
+++ b/project/StubServiceBuild.scala
@@ -14,17 +14,17 @@ object StubServiceBuild extends Build with MicroService {
   import play.sbt.PlayImport._
 
 
-  private val bookstrapPlay25Version    = "4.11.0"
-  private val hmrcTestVersion           = "3.8.0-play-25"
-  private val scalaTestVersion          = "3.0.0"
-  private val pegdownVersion            = "1.6.0"
+  private val bookstrapPlay25Version      = "4.12.0"
+  private val hmrcTestVersion             = "3.8.0-play-25"
+  private val scalaTestVersion            = "3.0.0"
+  private val pegdownVersion              = "1.6.0"
   private val simpleReactivemongoVersion  = "7.19.0-play-25"
   
   val compile = Seq(
     ws,
-    "uk.gov.hmrc"   %% "bootstrap-play-25"  % bookstrapPlay25Version,
-    "uk.gov.hmrc" %% "simple-reactivemongo"   % simpleReactivemongoVersion,
-    "org.typelevel" %% "cats"               % "0.9.0"
+    "uk.gov.hmrc"   %% "bootstrap-play-25"    % bookstrapPlay25Version,
+    "uk.gov.hmrc"   %% "simple-reactivemongo" % simpleReactivemongoVersion,
+    "org.typelevel" %% "cats"                 % "0.9.0"
   )
 
   trait TestDependencies {
@@ -37,11 +37,11 @@ object StubServiceBuild extends Build with MicroService {
       override lazy val test = Seq(
         "uk.gov.hmrc"             %% "hmrctest"           % hmrcTestVersion     % scope,
         "org.scalatest"           %% "scalatest"          % scalaTestVersion    % scope,
-        "org.pegdown"             % "pegdown"             % pegdownVersion      % scope,
+        "org.pegdown"             %  "pegdown"            % pegdownVersion      % scope,
         "com.typesafe.play"       %% "play-test"          % PlayVersion.current % scope,
-        "uk.gov.hmrc"             %% "reactivemongo-test" % "4.13.0-play-25"     % scope,
-        "org.scalatestplus.play"  %% "scalatestplus-play" % "2.0.0"             % scope,
-        "org.mockito"             % "mockito-all"         % "2.0.2-beta"        % scope
+        "uk.gov.hmrc"             %% "reactivemongo-test" % "4.14.0-play-25"    % scope,
+        "org.scalatestplus.play"  %% "scalatestplus-play" % "2.0.1"             % scope,
+        "org.mockito"             %  "mockito-all"        % "2.0.2-beta"        % scope
       )
     }.test
   }
@@ -53,12 +53,12 @@ object StubServiceBuild extends Build with MicroService {
 
       override lazy val test = Seq(
         "uk.gov.hmrc"             %% "hmrctest"           % hmrcTestVersion     % scope,
-        "org.scalatest"           %% "scalatest"          % "3.0.0"             % scope,
-        "org.pegdown"             % "pegdown"             % "1.5.0"             % scope,
+        "org.scalatest"           %% "scalatest"          % "3.0.7"             % scope,
+        "org.pegdown"             %  "pegdown"            % "1.5.0"             % scope,
         "com.typesafe.play"       %% "play-test"          % PlayVersion.current % scope,
-        "uk.gov.hmrc"             %% "reactivemongo-test" % "4.13.0-play-25"     % scope,
-        "org.scalatestplus.play"  %% "scalatestplus-play" % "2.0.0"             % scope,
-        "com.github.tomakehurst"  % "wiremock"            % "2.6.0"             % scope
+        "uk.gov.hmrc"             %% "reactivemongo-test" % "4.14.0-play-25"    % scope,
+        "org.scalatestplus.play"  %% "scalatestplus-play" % "2.0.1"             % scope,
+        "com.github.tomakehurst"  %  "wiremock"           % "2.23.2"            % scope
       )
     }.test
   }


### PR DESCRIPTION
# SAR-3853: Removed reliance on deprecated methods

**Bug fix + Spike**

After experiencing similar issues on `enrolment-activation-printing`, BRDS was volunteered to have it's deprecated mongo methods updated, after a conversation with @ChrisHillCap. This is the output. - - Deprecated mongo methods remove and updated.
- Dependencies updated.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
